### PR TITLE
Update to syllabus from workshop-template

### DIFF
--- a/_includes/dc/syllabus.html
+++ b/_includes/dc/syllabus.html
@@ -98,10 +98,11 @@ The syllabus for the different curricula are listed here:
   <div class="col-md-6">
     <h3 id="syllabus-genomics-wrangling">Data Wrangling and Processing for Genomics</h3>
     <ul>
-      <li><a href="https://datacarpentry.org/wrangling-genomics/00-quality-control/index.html">Assessing Read Quality</a></li>
-      <li><a href="https://datacarpentry.org/wrangling-genomics/01-trimming/index.html">Trimming and Filtering</a></li>
-      <li><a href="https://datacarpentry.org/wrangling-genomics/02-variant_calling/index.html">Variant Calling Workflow</a></li>
-      <li><a href="https://datacarpentry.org/wrangling-genomics/03-automation/index.html">Automating a Variant Calling Workflow</a></li>
+      <li><a href="https://datacarpentry.org/wrangling-genomics/01-background/index.html">Background and Metadata</a></li>
+      <li><a href="https://datacarpentry.org/wrangling-genomics/02-quality-control/index.html">Assessing Read Quality</a></li>
+      <li><a href="https://datacarpentry.org/wrangling-genomics/03-trimming/index.html">Trimming and Filtering</a></li>
+      <li><a href="https://datacarpentry.org/wrangling-genomics/04-variant_calling/index.html">Variant Calling Workflow</a></li>
+      <li><a href="https://datacarpentry.org/wrangling-genomics/05-automation/index.html">Automating a Variant Calling Workflow</a></li>
     </ul>
   </div>
   <div class="col-md-6">
@@ -110,8 +111,7 @@ The syllabus for the different curricula are listed here:
       <li><a href="https://datacarpentry.org/cloud-genomics/01-why-cloud-computing/index.html">Why of Cloud Computing</a></li>
       <li><a href="https://datacarpentry.org/cloud-genomics/02-logging-onto-cloud/index.html">Logging onto Cloud</a></li>
       <li><a href="https://datacarpentry.org/cloud-genomics/03-verifying-instance/index.html">Fine Tuning your Cloud Setup</a></li>
-      <li><a href="https://datacarpentry.org/cloud-genomics/04-data-roundtripping/index.html">Data Roundtripping</a></li>
-      <li><a href="https://datacarpentry.org/cloud-genomics/05-which-cloud/index.html">Which Cloud for my Data?</a></li>
+      <li><a href="https://datacarpentry.org/cloud-genomics/04-which-cloud/index.html">Which Cloud for my Data?</a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION

Hi Nick,

The syllabus links have changed in the workshop-template: roundtripping data is no longer a separate section, and there's a new background and metadata section in data wrangling. This pull request should fix the workshop page.

